### PR TITLE
Use Argument `asAes` to maintain the data structure

### DIFF
--- a/R/loon2ggplot.R
+++ b/R/loon2ggplot.R
@@ -348,7 +348,7 @@ loon2ggplot.l_layer_group <- function(target, asAes = TRUE, selectedOnTop = TRUE
         )
 
         if(selectedOnTop) {
-          displayOrder <- get_model_display_order(widget)
+          displayOrder <- suppressWarnings(get_model_display_order(widget))
           data <- data[displayOrder, ]
         }
 

--- a/R/loon2ggplot.R
+++ b/R/loon2ggplot.R
@@ -347,6 +347,11 @@ loon2ggplot.l_layer_group <- function(target, asAes = TRUE, selectedOnTop = TRUE
             ), as_list = FALSE)
         )
 
+        if(selectedOnTop) {
+          displayOrder <- get_model_display_order(widget)
+          data <- data[displayOrder, ]
+        }
+
         if(length(x) > 0) {
 
           if(inherits(widget, "l_hist")) {

--- a/R/loon2ggplot_l_layer_histogram.R
+++ b/R/loon2ggplot_l_layer_histogram.R
@@ -34,10 +34,8 @@ loon2ggplot.l_layer_histogram <- function(target, asAes = TRUE, selectedOnTop = 
         labels = values)
 
     uniFill <- unique(fill[!is.na(fill)])
-
-    if(length(uniFill) <= 1) {
+    if(length(uniFill) <= 1)
       ggObj <- ggObj + ggplot2::guides(color = FALSE, fill = FALSE)
-    }
 
   } else {
 

--- a/R/loon2ggplot_l_layer_scatterplot.R
+++ b/R/loon2ggplot_l_layer_scatterplot.R
@@ -6,11 +6,10 @@ loon2ggplot.l_layer_scatterplot <- function(target, asAes = TRUE, selectedOnTop 
   widget <- loon::l_create_handle(attr(target, "widget"))
   swapAxes <- widget["swapAxes"]
 
-  # layer scatterplot shares the same data set with the ggplot model layer
   ggObj <- list(...)$ggObj
-  data <- ggObj$data
+  states <- get_layer_states(widget, native_unit = FALSE)
 
-  if (!any(data$active)) return(ggObj)
+  if (!any(states$active)) return(ggObj)
 
   # No active points in scatterplot
   displayOrder <- if(selectedOnTop) {
@@ -19,15 +18,15 @@ loon2ggplot.l_layer_scatterplot <- function(target, asAes = TRUE, selectedOnTop 
     seq(widget['n'])
   }
 
-  active <- data$active[displayOrder]
-  selected <- data$selected[displayOrder][active]
+  active <- states$active[displayOrder]
+  selected <- states$selected[displayOrder][active]
 
   s_a <- list(
-    x = if(swapAxes) data$y[displayOrder][active] else data$x[displayOrder][active],
-    y = if(swapAxes) data$x[displayOrder][active] else data$y[displayOrder][active],
-    glyph = data$glyph[displayOrder][active],
-    color = get_display_color(data$color[displayOrder][active], selected),
-    size = data$size[displayOrder][active],
+    x = if(swapAxes) states$y[displayOrder][active] else states$x[displayOrder][active],
+    y = if(swapAxes) states$x[displayOrder][active] else states$y[displayOrder][active],
+    glyph = states$glyph[displayOrder][active],
+    color = get_display_color(states$color[displayOrder][active], selected),
+    size = states$size[displayOrder][active],
     index = displayOrder[active]
   )
 

--- a/R/loon2ggplot_l_serialaxes.R
+++ b/R/loon2ggplot_l_serialaxes.R
@@ -3,7 +3,6 @@
 loon2ggplot.l_serialaxes <- function(target, asAes = TRUE, selectedOnTop = TRUE, ...) {
 
   widget <- target
-  remove(target)
   serialaxes.data <- char2num.data.frame(widget['data'])
   colNames <- colnames(serialaxes.data)
 
@@ -14,8 +13,14 @@ loon2ggplot.l_serialaxes <- function(target, asAes = TRUE, selectedOnTop = TRUE,
     seq(widget['n'])
   }
 
-  ndimNames <- loon::l_nDimStateNames(widget)
+  # We do not call `get_layer_states(widget, native_unit = FALSE)`
+  # Because, `loon::l_nDimStateNames` will return all n dimensional states,
+  # but the `get_layer_states` only return the n dimensional aesthetics attributes
+  # e.g, `itemLabels` will not be returned.
+  # `data` is used in `ggplot()`
+
   # N dim names
+  ndimNames <- loon::l_nDimStateNames(widget)
   data <- as.data.frame(
     remove_null(
       stats::setNames(
@@ -78,15 +83,13 @@ loon2ggplot.l_serialaxes <- function(target, asAes = TRUE, selectedOnTop = TRUE,
                                     breaks = uni_color)
     }
 
-    if(length(uni_color) <= 1) {
+    if(length(uni_color) <= 1)
       ggObj <- ggObj + ggplot2::guides(color = FALSE)
-    }
 
     uni_size <- unique(size)
-    if(length(uni_size) > 0) {
+    if(length(uni_size) > 0)
       ggObj <- ggObj +
         ggplot2::scale_size(range = range(size[!is.na(size)]))
-    }
 
     if(length(uni_size) <= 1)
       ggObj <- ggObj + ggplot2::guides(size = FALSE)


### PR DESCRIPTION
An alternative way to maintain the data structure in a large extent of loon in ggplot is to set `asAes = FALSE`. For example, 
```
p <- l_plot(iris, glyph = sample(c("circle", "ccircle"), 150, replace = TRUE))
g1 <- loon.ggplot(p)
g2 <- loon.ggplot(p, asAes = FALSE)
b1 <- ggplot_build(g1)
b2 <- ggplot_build(g2)
# two layers
length(b1$data)
# only one layer
length(b2$data)
```